### PR TITLE
Support CORS policy for requests

### DIFF
--- a/src/server/ctx/util.rs
+++ b/src/server/ctx/util.rs
@@ -39,6 +39,9 @@ pub fn html_headers() -> HeaderMap {
 pub fn json_headers() -> HeaderMap {
     let mut headers = HeaderMap::new();
     headers.insert(header::CONTENT_TYPE, "application/json".parse().unwrap());
+    headers.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, "*".parse().unwrap());
+    headers.insert(header::ACCESS_CONTROL_ALLOW_METHODS, "GET, POST, OPTIONS".parse().unwrap());
+    headers.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, "Content-Type".parse().unwrap());
     headers
 }
 


### PR DESCRIPTION
Because websites need to be separated from the front end, cross-domain access requests are required.
After the merge, pelease redistribute a version and redeploy it.
Thank you.
![image](https://github.com/user-attachments/assets/a48be786-88bb-4689-a015-32962586f274)

